### PR TITLE
feat: add OpenAlex literature source + chemistry domain config

### DIFF
--- a/bin/lit_review.py
+++ b/bin/lit_review.py
@@ -2,10 +2,10 @@
 """
 lit_review.py — Literature review: search, rank, download.
 
-Supports arXiv and PubMed sources.
+Supports arXiv, PubMed, and OpenAlex sources.
 
 Usage:
-    python3 lit_review.py search "query" --dir /path [--source arxiv|pubmed] [--max-papers 50] [--abstracts-only]
+    python3 lit_review.py search "query" --dir /path [--source arxiv|pubmed|openalex] [--max-papers 50] [--abstracts-only]
     python3 lit_review.py cleanup --dir /path --keep 50 "overall topic description"
     python3 lit_review.py list --dir /path
 """
@@ -34,6 +34,10 @@ ARXIV_DELAY = 3  # seconds between arXiv requests
 PUBMED_ESEARCH = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
 PUBMED_EFETCH = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
 PUBMED_DELAY = 1  # seconds between PubMed requests (3 req/s without key)
+
+OPENALEX_API = "https://api.openalex.org/works"
+OPENALEX_DELAY = 0.1  # seconds between OpenAlex requests (generous rate limits)
+OPENALEX_EMAIL = "langer.robin@gmail.com"  # polite pool — faster responses
 
 # SSL context for HTTPS requests (macOS Python sometimes lacks system certs)
 _ssl_ctx = ssl.create_default_context()
@@ -296,6 +300,155 @@ def _parse_pubmed_article(article_el):
     }
 
 
+# ── OpenAlex API ──────────────────────────────────────────────────────
+
+def _openalex_abstract(inverted_index):
+    """Reconstruct plain-text abstract from OpenAlex abstract_inverted_index.
+
+    OpenAlex stores abstracts as {word: [position, ...]} mappings rather than
+    plain text (a compact representation that avoids copyright issues).  This
+    helper reverses the mapping back into a readable string.
+
+    Args:
+        inverted_index: dict mapping each word to a list of integer positions,
+            e.g. {"The": [0], "effect": [1], "of": [2], ...}.  May be None.
+
+    Returns:
+        Reconstructed abstract string, or empty string if the index is absent
+        or empty.
+    """
+    if not inverted_index:
+        return ''
+    # Build a position→word mapping, then sort and join.
+    position_word = {}
+    for word, positions in inverted_index.items():
+        for pos in positions:
+            position_word[pos] = word
+    if not position_word:
+        return ''
+    ordered = [position_word[i] for i in sorted(position_word)]
+    return ' '.join(ordered)
+
+
+def search_openalex(query_terms, max_results=200):
+    """Search OpenAlex API and return a list of paper metadata dicts.
+
+    Uses the polite-pool endpoint (mailto parameter) for better rate limits.
+    Skips records that have no reconstructible abstract, matching the behaviour
+    of the other source functions which require an abstract for embedding.
+
+    Args:
+        query_terms: Free-text query string.
+        max_results: Maximum number of results to return (default 200).
+
+    Returns:
+        List of paper dicts with keys: base_id, title, abstract, authors,
+        published, pdf_url, doi, source.
+    """
+    candidates = []
+    page_size = min(200, max_results)  # OpenAlex allows up to 200 per page
+    pages_needed = (max_results + page_size - 1) // page_size
+
+    for page in range(1, pages_needed + 1):
+        remaining = max_results - len(candidates)
+        fetch = min(page_size, remaining)
+
+        params = urllib.parse.urlencode({
+            'search': query_terms,
+            'per-page': fetch,
+            'page': page,
+            'mailto': OPENALEX_EMAIL,
+        })
+        url = f"{OPENALEX_API}?{params}"
+
+        if page > 1:
+            print(f"  Waiting {OPENALEX_DELAY}s before next OpenAlex page...")
+            time.sleep(OPENALEX_DELAY)
+
+        print(f"  Fetching OpenAlex results (page {page})...")
+        try:
+            req = urllib.request.Request(url, headers={'User-Agent': 'lit-review-tool/1.0'})
+            with urllib.request.urlopen(req, timeout=30, context=_ssl_ctx) as resp:
+                data = json.loads(resp.read().decode('utf-8'))
+        except Exception as e:
+            print(f"  Warning: OpenAlex API request failed: {e}")
+            break
+
+        results = data.get('results', [])
+        if not results:
+            break
+
+        for work in results:
+            paper = _parse_openalex_work(work)
+            if paper:
+                candidates.append(paper)
+
+        if len(results) < fetch:
+            break  # Fewer results than requested — no more pages
+
+    return candidates
+
+
+def _parse_openalex_work(work):
+    """Parse a single OpenAlex work object into a paper metadata dict.
+
+    Returns None if the work lacks an abstract (we need it for embedding).
+
+    The returned dict shape matches _parse_pubmed_article: base_id, title,
+    abstract, authors, published, pdf_url, doi, source.
+    """
+    # Abstract — skip works with no usable abstract
+    abstract = _openalex_abstract(work.get('abstract_inverted_index'))
+    if not abstract.strip():
+        return None
+
+    title = (work.get('title') or '').strip()
+    if not title:
+        return None
+
+    # Stable identifier: prefer DOI, fall back to OpenAlex ID
+    doi = work.get('doi')  # e.g. "https://doi.org/10.1021/..."
+    openalex_id = work.get('id', '')  # e.g. "https://openalex.org/W2741809807"
+    short_id = openalex_id.split('/')[-1] if openalex_id else ''
+
+    if doi:
+        # Normalise to bare DOI path (strip "https://doi.org/")
+        bare_doi = doi.replace('https://doi.org/', '').replace('http://doi.org/', '')
+        base_id = f"doi_{bare_doi.replace('/', '_').replace('.', '_')}"
+    elif short_id:
+        base_id = f"openalex_{short_id}"
+    else:
+        return None  # No usable identifier
+
+    # Authors
+    authors = []
+    for authorship in work.get('authorships', []):
+        author = authorship.get('author', {})
+        name = author.get('display_name', '').strip()
+        if name:
+            authors.append(name)
+
+    # Publication year → published string (consistent with PubMed's year-only fallback)
+    year = work.get('publication_year')
+    published = str(year) if year else ''
+
+    # PDF URL: OpenAlex exposes open-access PDF via best_oa_location
+    pdf_url = None
+    best_oa = work.get('best_oa_location') or {}
+    pdf_url = best_oa.get('pdf_url')  # None for paywalled works — intentional
+
+    return {
+        'base_id': base_id,
+        'title': ' '.join(title.split()),
+        'abstract': ' '.join(abstract.split()),
+        'authors': authors,
+        'published': published,
+        'pdf_url': pdf_url,
+        'doi': doi,
+        'source': 'openalex',
+    }
+
+
 # ── Embedding-based ranking ───────────────────────────────────────────
 
 def rank_by_relevance(query_text, candidates, openai_client, top_n=50):
@@ -361,6 +514,8 @@ def cmd_search(query_terms, output_dir, max_papers=50, abstracts_only=False, sou
     print(f"[Phase 1/3] Searching {source}...")
     if source == 'pubmed':
         candidates = search_pubmed(query_terms, max_results=200)
+    elif source == 'openalex':
+        candidates = search_openalex(query_terms, max_results=200)
     else:
         candidates = search_arxiv(query_terms, max_results=200)
     print(f"  Found {len(candidates)} candidates\n")
@@ -416,7 +571,12 @@ def cmd_search(query_terms, output_dir, max_papers=50, abstracts_only=False, sou
     # Download PDFs (unless abstracts-only)
     downloaded = 0
     skipped_no_pdf = 0
-    delay = PUBMED_DELAY if source == 'pubmed' else ARXIV_DELAY
+    if source == 'pubmed':
+        delay = PUBMED_DELAY
+    elif source == 'openalex':
+        delay = OPENALEX_DELAY
+    else:
+        delay = ARXIV_DELAY
     if abstracts_only:
         print("[Phase 3/3] Skipping PDF download (--abstracts-only)")
     else:
@@ -617,8 +777,8 @@ def main():
                 i += 2
             elif args[i] == '--source' and i + 1 < len(args):
                 source = args[i + 1].lower()
-                if source not in ('arxiv', 'pubmed'):
-                    print(f"Error: --source must be 'arxiv' or 'pubmed', got '{source}'")
+                if source not in ('arxiv', 'pubmed', 'openalex'):
+                    print(f"Error: --source must be 'arxiv', 'pubmed', or 'openalex', got '{source}'")
                     sys.exit(1)
                 i += 2
             elif args[i] == '--abstracts-only':

--- a/configs/chemistry.yaml
+++ b/configs/chemistry.yaml
@@ -1,0 +1,234 @@
+# Domain configuration: Physical Chemistry — Framework Materials & Enzyme Immobilisation
+# Focus: HOF/MOF biocatalysis, electronic-vibronic effects, redox-centre chemistry
+name: chemistry
+
+# ── Extraction ────────────────────────────────────────────────────────
+extraction_prompt: |
+  You are a physical chemistry and materials-science knowledge extractor.
+  Given text from a research paper, extract:
+
+  1. **Concepts**: Framework materials (MOFs, HOFs, COFs), enzymes and cofactors,
+     characterisation methods, chemical interactions, reaction mechanisms,
+     redox centres, spectroscopic signatures, and key researchers mentioned.
+  2. **Relationships**: How concepts relate to each other — what encapsulates what,
+     which methods characterise which materials, how electronic and vibronic effects
+     modulate reactivity.
+
+  Return JSON with this exact schema:
+  {
+    "concepts": [
+      {
+        "name": "short canonical name (e.g., 'hydrogen-bonded organic framework')",
+        "type": "one of: framework, enzyme, cofactor, characterization-method, interaction, mechanism, redox-center, spectral-feature, material, technique, person, definition",
+        "description": "one sentence description if clear from context"
+      }
+    ],
+    "relationships": [
+      {
+        "source": "concept name (must match a concept above)",
+        "target": "concept name (must match a concept above)",
+        "relation": "one of: encapsulates, coordinates-to, characterized-by, modulates, couples-to, catalyzes, inhibits, stabilizes, subtype_of, synthesized-by, related_to, developed_by",
+        "detail": "brief explanation"
+      }
+    ]
+  }
+
+  Rules:
+  - Use canonical IUPAC or widely accepted names (e.g., "horseradish peroxidase" not "HRP enzyme")
+  - Prefer established nomenclature over ad-hoc descriptions
+  - Extract 3-15 concepts per passage (focus on the most important ones)
+  - Only include relationships that are explicitly stated or clearly implied
+  - For people, only include them if they are credited with developing a specific material,
+    method, or mechanistic insight
+  - Distinguish characterisation methods from the materials/species they probe
+
+concept_types:
+  - framework
+  - enzyme
+  - cofactor
+  - characterization-method
+  - interaction
+  - mechanism
+  - redox-center
+  - spectral-feature
+  - material
+  - technique
+  - person
+  - definition
+
+relationship_types:
+  - encapsulates
+  - coordinates-to
+  - characterized-by
+  - modulates
+  - couples-to
+  - catalyzes
+  - inhibits
+  - stabilizes
+  - subtype_of
+  - synthesized-by
+  - related_to
+  - developed_by
+
+type_colors:
+  framework: "#2980B9"
+  enzyme: "#27AE60"
+  cofactor: "#8E44AD"
+  characterization-method: "#E67E22"
+  interaction: "#16A085"
+  mechanism: "#C0392B"
+  redox-center: "#D35400"
+  spectral-feature: "#7F8C8D"
+  material: "#2C3E50"
+  technique: "#F39C12"
+  person: "#795548"
+  definition: "#607D8B"
+
+normalize:
+  # Framework abbreviations
+  "mof": "metal-organic framework"
+  "mofs": "metal-organic framework"
+  "metal organic framework": "metal-organic framework"
+  "hof": "hydrogen-bonded organic framework"
+  "hofs": "hydrogen-bonded organic framework"
+  "hydrogen bonded organic framework": "hydrogen-bonded organic framework"
+  "cof": "covalent organic framework"
+  "cofs": "covalent organic framework"
+  "covalent organic framework": "covalent organic framework"
+  "zif": "zeolitic imidazolate framework"
+  "zif-8": "zeolitic imidazolate framework-8"
+  "uio-66": "UiO-66"
+  "mil-101": "MIL-101"
+  "pcn": "porous coordination network"
+
+  # Enzymes
+  "hrp": "horseradish peroxidase"
+  "horseradish peroxidase": "horseradish peroxidase"
+  "lac": "laccase"
+  "lip": "lignin peroxidase"
+  "mnp": "manganese peroxidase"
+  "glucose oxidase": "glucose oxidase"
+  "gox": "glucose oxidase"
+  "alcohol oxidase": "alcohol oxidase"
+  "cytochrome c": "cytochrome c"
+  "cyt c": "cytochrome c"
+  "cytochrome p450": "cytochrome P450"
+  "p450": "cytochrome P450"
+
+  # Cofactors and redox centres
+  "heme": "haem"
+  "haem": "haem"
+  "fad": "flavin adenine dinucleotide"
+  "flavin adenine dinucleotide": "flavin adenine dinucleotide"
+  "fmn": "flavin mononucleotide"
+  "nad": "nicotinamide adenine dinucleotide"
+  "nadh": "nicotinamide adenine dinucleotide (reduced)"
+  "nad+": "nicotinamide adenine dinucleotide (oxidised)"
+  "cu": "copper centre"
+  "type-1 copper": "type-1 copper centre"
+  "t1 copper": "type-1 copper centre"
+
+  # Characterisation methods
+  "xrd": "X-ray diffraction"
+  "pxrd": "powder X-ray diffraction"
+  "powder xrd": "powder X-ray diffraction"
+  "sc-xrd": "single-crystal X-ray diffraction"
+  "ftir": "FTIR spectroscopy"
+  "ir spectroscopy": "FTIR spectroscopy"
+  "uv-vis": "UV-vis spectroscopy"
+  "uv/vis": "UV-vis spectroscopy"
+  "uv-visible spectroscopy": "UV-vis spectroscopy"
+  "epr": "EPR spectroscopy"
+  "electron paramagnetic resonance": "EPR spectroscopy"
+  "eseem": "ESEEM spectroscopy"
+  "endor": "ENDOR spectroscopy"
+  "raman": "Raman spectroscopy"
+  "sem": "scanning electron microscopy"
+  "tem": "transmission electron microscopy"
+  "bet": "BET surface area analysis"
+  "bet surface area": "BET surface area analysis"
+  "tga": "thermogravimetric analysis"
+  "dsc": "differential scanning calorimetry"
+  "nmr": "NMR spectroscopy"
+  "cyclic voltammetry": "cyclic voltammetry"
+  "cv": "cyclic voltammetry"
+
+  # Interactions and mechanisms
+  "vibronic coupling": "vibronic coupling"
+  "electron-phonon coupling": "vibronic coupling"
+  "electronic-vibronic coupling": "vibronic coupling"
+  "hydrogen bonding": "hydrogen bonding"
+  "h-bonding": "hydrogen bonding"
+  "pi-pi stacking": "pi-pi stacking"
+  "pi stacking": "pi-pi stacking"
+  "coordination bond": "coordination bond"
+  "pcet": "proton-coupled electron transfer"
+  "proton coupled electron transfer": "proton-coupled electron transfer"
+  "et": "electron transfer"
+  "electron transfer": "electron transfer"
+  "oxidative catalysis": "oxidative catalysis"
+  "reductive catalysis": "reductive catalysis"
+
+# ── Collection names ──────────────────────────────────────────────────
+collection_names:
+  - lit_review
+  - chemistry_papers
+
+ingest_collection: lit_review
+
+# ── Summary generation ────────────────────────────────────────────────
+summary_system_prompt: |
+  You are a physical chemistry encyclopedia writer specialising in framework
+  materials, enzyme immobilisation, and biocatalysis. Write clear, precise
+  reference summaries that bridge structural chemistry (MOF/HOF topology,
+  pore environment) with function (enzyme stability, substrate access,
+  electronic effects). Focus on mechanistic insight and practical relevance
+  for synthetic chemists and materials scientists.
+
+summary_sections:
+  - "## Definition\nPrecise definition of this concept. Include formal names, acronyms, and key structural features where applicable."
+  - "## Structural or Mechanistic Basis\nHow this concept is realised at the molecular or electronic level. Include key interactions, geometries, or pathways."
+  - "## Characterisation\nHow this is measured or identified. Include specific spectroscopic, diffraction, or electrochemical methods."
+  - "## Role in Biocatalysis / Framework Chemistry\nHow this concept functions within MOF/HOF host-guest systems or enzyme immobilisation contexts."
+  - "## Connections\nHow this concept relates to other frameworks, enzymes, mechanisms, or spectral features in the chemistry landscape."
+  - "## References\nList the source papers cited in the passages."
+
+# ── Level 2 theme identification ──────────────────────────────────────
+theme_domain_description: |
+  physical chemistry and materials science, focusing on hydrogen-bonded organic
+  frameworks (HOFs) and metal-organic frameworks (MOFs) as hosts for enzyme
+  immobilisation and biocatalysis; electronic-vibronic coupling effects on redox
+  enzyme activity; EPR and optical spectroscopy of metalloenzyme active sites;
+  copper- and haem-based oxidases (laccase, horseradish peroxidase, cytochrome P450);
+  proton-coupled electron transfer; porous framework design for substrate access;
+  and structural characterisation via XRD, BET, TGA, and FTIR
+
+meta_summary_system_prompt: |
+  You are a physical chemistry research surveyor writing comprehensive overviews
+  of framework-based biocatalysis for materials chemists and biochemists.
+
+l2_graph_domain_description: |
+  physical chemistry, specifically porous framework materials (MOFs, HOFs, COFs)
+  as hosts for enzyme immobilisation, and the electronic/vibronic effects that
+  govern redox enzyme function
+
+# ── Survey generation ─────────────────────────────────────────────────
+survey_section_system: |
+  You are an expert academic survey writer producing LaTeX content for a survey
+  paper on framework-based enzyme immobilisation and biocatalysis.
+  Write in formal academic style with proper LaTeX formatting. Use \label{}
+  for sections/subsections and \ref{} for cross-references. Use \cite{}
+  for citations (cite keys are doi_XXXXXX or openalex_WXXXXXX format).
+  Do NOT include \begin{document} or preamble — just the section content.
+
+survey_abstract_domain: |
+  This survey reviews the immobilisation of oxidoreductase enzymes within
+  porous framework hosts (MOFs, HOFs, COFs), with emphasis on how the host
+  pore environment modulates electronic-vibronic coupling at redox-active
+  centres (haem, copper, FAD), the structural characterisation of
+  host-guest assemblies, and the catalytic consequences for oxidative
+  transformations of industrial and pharmaceutical relevance.
+
+# ── Structural holes ─────────────────────────────────────────────────
+cluster_description_domain: "physical chemistry, framework materials, and enzyme biocatalysis research"
+search_query_domain: "MOF HOF enzyme immobilisation biocatalysis electronic vibronic"

--- a/tests/test_lit_review.py
+++ b/tests/test_lit_review.py
@@ -1,0 +1,234 @@
+"""Tests for bin/lit_review.py — OpenAlex source and abstract reconstruction.
+
+These tests mock all HTTP calls; no network access occurs.
+"""
+
+import json
+import sys
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make the bin/ directory importable so we can import lit_review directly.
+sys.path.insert(0, str(Path(__file__).parent.parent / "bin"))
+import lit_review
+
+
+# ---------------------------------------------------------------------------
+# _openalex_abstract — inverted-index reconstruction
+# ---------------------------------------------------------------------------
+
+class TestOpenAlexAbstract:
+    """Unit tests for the abstract_inverted_index → plain text helper."""
+
+    def test_basic_reconstruction(self):
+        inverted = {"The": [0], "quick": [1], "brown": [2], "fox": [3]}
+        result = lit_review._openalex_abstract(inverted)
+        assert result == "The quick brown fox"
+
+    def test_multi_occurrence_word(self):
+        # "the" appears at positions 0 and 3
+        inverted = {"the": [0, 3], "cat": [1], "sat": [2]}
+        result = lit_review._openalex_abstract(inverted)
+        assert result == "the cat sat the"
+
+    def test_none_returns_empty(self):
+        assert lit_review._openalex_abstract(None) == ''
+
+    def test_empty_dict_returns_empty(self):
+        assert lit_review._openalex_abstract({}) == ''
+
+    def test_preserves_word_order(self):
+        # Positions are non-contiguous but should still be sorted correctly
+        inverted = {"C": [2], "A": [0], "B": [1]}
+        result = lit_review._openalex_abstract(inverted)
+        assert result == "A B C"
+
+    def test_realistic_chemistry_abstract(self):
+        inverted = {
+            "Enzyme": [0],
+            "immobilisation": [1],
+            "within": [2],
+            "metal-organic": [3],
+            "frameworks": [4],
+            "enhances": [5],
+            "stability.": [6],
+        }
+        result = lit_review._openalex_abstract(inverted)
+        assert result == "Enzyme immobilisation within metal-organic frameworks enhances stability."
+
+
+# ---------------------------------------------------------------------------
+# _parse_openalex_work — dict-shape contract
+# ---------------------------------------------------------------------------
+
+class TestParseOpenAlexWork:
+    """Verify that _parse_openalex_work returns the expected dict shape."""
+
+    def _sample_work(self, **overrides):
+        """Minimal valid OpenAlex work object."""
+        base = {
+            "id": "https://openalex.org/W1234567890",
+            "title": "HOF enzyme immobilisation study",
+            "publication_year": 2023,
+            "doi": "https://doi.org/10.1021/jacs.3c01234",
+            "abstract_inverted_index": {
+                "Porous": [0], "frameworks": [1], "encapsulate": [2], "enzymes.": [3]
+            },
+            "authorships": [
+                {"author": {"display_name": "Robin Langer"}},
+                {"author": {"display_name": "Jane Smith"}},
+            ],
+            "best_oa_location": None,
+        }
+        base.update(overrides)
+        return base
+
+    def test_returns_expected_keys(self):
+        work = self._sample_work()
+        result = lit_review._parse_openalex_work(work)
+        assert result is not None
+        for key in ("base_id", "title", "abstract", "authors", "published",
+                    "pdf_url", "doi", "source"):
+            assert key in result, f"Missing key: {key}"
+
+    def test_source_is_openalex(self):
+        result = lit_review._parse_openalex_work(self._sample_work())
+        assert result["source"] == "openalex"
+
+    def test_doi_used_as_base_id(self):
+        result = lit_review._parse_openalex_work(self._sample_work())
+        # DOI: 10.1021/jacs.3c01234 → base_id encodes it
+        assert result["base_id"].startswith("doi_")
+        assert "10_1021" in result["base_id"]
+
+    def test_openalex_id_fallback_when_no_doi(self):
+        work = self._sample_work(doi=None)
+        result = lit_review._parse_openalex_work(work)
+        assert result is not None
+        assert result["base_id"].startswith("openalex_W")
+
+    def test_abstract_reconstructed(self):
+        result = lit_review._parse_openalex_work(self._sample_work())
+        assert "Porous" in result["abstract"]
+        assert "enzymes." in result["abstract"]
+
+    def test_returns_none_when_no_abstract(self):
+        work = self._sample_work(abstract_inverted_index=None)
+        assert lit_review._parse_openalex_work(work) is None
+
+    def test_returns_none_when_empty_abstract(self):
+        work = self._sample_work(abstract_inverted_index={})
+        assert lit_review._parse_openalex_work(work) is None
+
+    def test_returns_none_when_no_title(self):
+        work = self._sample_work(title=None)
+        assert lit_review._parse_openalex_work(work) is None
+
+    def test_returns_none_when_no_id_and_no_doi(self):
+        work = self._sample_work(id=None, doi=None)
+        assert lit_review._parse_openalex_work(work) is None
+
+    def test_authors_extracted(self):
+        result = lit_review._parse_openalex_work(self._sample_work())
+        assert result["authors"] == ["Robin Langer", "Jane Smith"]
+
+    def test_published_year(self):
+        result = lit_review._parse_openalex_work(self._sample_work())
+        assert result["published"] == "2023"
+
+    def test_pdf_url_none_for_paywalled(self):
+        work = self._sample_work(best_oa_location=None)
+        result = lit_review._parse_openalex_work(work)
+        assert result["pdf_url"] is None
+
+    def test_pdf_url_from_oa_location(self):
+        work = self._sample_work(
+            best_oa_location={"pdf_url": "https://example.com/paper.pdf"}
+        )
+        result = lit_review._parse_openalex_work(work)
+        assert result["pdf_url"] == "https://example.com/paper.pdf"
+
+
+# ---------------------------------------------------------------------------
+# search_openalex — mocked HTTP
+# ---------------------------------------------------------------------------
+
+def _make_openalex_response(works):
+    """Build a minimal OpenAlex /works JSON response."""
+    payload = json.dumps({"results": works}).encode("utf-8")
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = payload
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+def _sample_work_fixture():
+    return {
+        "id": "https://openalex.org/W9999999999",
+        "title": "Vibronic coupling in laccase immobilised on MOF",
+        "publication_year": 2024,
+        "doi": "https://doi.org/10.1039/d4sc01234a",
+        "abstract_inverted_index": {
+            "Laccase": [0], "immobilised": [1], "on": [2],
+            "MOF": [3], "shows": [4], "vibronic": [5], "coupling.": [6],
+        },
+        "authorships": [{"author": {"display_name": "A. Chemist"}}],
+        "best_oa_location": None,
+    }
+
+
+class TestSearchOpenAlex:
+    """Integration-level tests for search_openalex with mocked urllib."""
+
+    @patch("urllib.request.urlopen")
+    def test_returns_list_of_dicts(self, mock_urlopen):
+        mock_urlopen.return_value = _make_openalex_response([_sample_work_fixture()])
+        results = lit_review.search_openalex("laccase MOF vibronic", max_results=1)
+        assert isinstance(results, list)
+        assert len(results) == 1
+
+    @patch("urllib.request.urlopen")
+    def test_dict_shape_contract(self, mock_urlopen):
+        mock_urlopen.return_value = _make_openalex_response([_sample_work_fixture()])
+        results = lit_review.search_openalex("laccase MOF", max_results=1)
+        paper = results[0]
+        for key in ("base_id", "title", "abstract", "authors", "published",
+                    "pdf_url", "doi", "source"):
+            assert key in paper, f"Missing key in search result: {key}"
+        assert paper["source"] == "openalex"
+
+    @patch("urllib.request.urlopen")
+    def test_skips_works_without_abstract(self, mock_urlopen):
+        no_abstract = dict(_sample_work_fixture())
+        no_abstract["abstract_inverted_index"] = None
+        mock_urlopen.return_value = _make_openalex_response([no_abstract])
+        results = lit_review.search_openalex("laccase MOF", max_results=5)
+        assert results == []
+
+    @patch("urllib.request.urlopen")
+    def test_empty_results_returns_empty_list(self, mock_urlopen):
+        mock_urlopen.return_value = _make_openalex_response([])
+        results = lit_review.search_openalex("no results query", max_results=10)
+        assert results == []
+
+    @patch("urllib.request.urlopen")
+    def test_network_error_returns_empty_list(self, mock_urlopen):
+        mock_urlopen.side_effect = Exception("Connection refused")
+        results = lit_review.search_openalex("any query", max_results=10)
+        assert results == []
+
+    @patch("urllib.request.urlopen")
+    def test_mailto_in_request_url(self, mock_urlopen):
+        """Polite-pool email is included in the API request URL (URL-encoded form)."""
+        mock_urlopen.return_value = _make_openalex_response([_sample_work_fixture()])
+        lit_review.search_openalex("enzyme framework", max_results=1)
+        call_args = mock_urlopen.call_args
+        # urlopen receives a Request object; get its full_url.
+        # urllib.parse.urlencode encodes '@' as '%40', so check for both forms.
+        request_obj = call_args[0][0]
+        url = request_obj.full_url
+        assert "langer.robin" in url and ("gmail.com" in url or "gmail" in url)


### PR DESCRIPTION
## Summary

This PR generalises INSTINCT past arXiv/PubMed into two new dimensions:

- **OpenAlex as a literature source** — covers paywalled chemistry journals (ACS, RSC, Wiley, Nature) and provides citation-graph data. OpenAlex indexes 250M+ works and its polite-pool endpoint (used here via `mailto`) gives generous rate limits and fast responses.
- **Chemistry domain config** — tuned for physical chemistry / framework materials / enzyme immobilisation, the HOF/MOF biocatalysis domain you've been building toward.

## What was added

### `bin/lit_review.py`
- `OPENALEX_API`, `OPENALEX_DELAY` (0.1 s), `OPENALEX_EMAIL` constants
- `_openalex_abstract(inverted_index)` — reconstructs plain text from OpenAlex's compact `abstract_inverted_index` format (word → [positions])
- `_parse_openalex_work(work)` — parses a single OpenAlex work object into the same dict shape as `_parse_pubmed_article` (keys: `base_id`, `title`, `abstract`, `authors`, `published`, `pdf_url`, `doi`, `source`). Returns `None` for works with no abstract, so embedding ranking always has content to work with. Paywalled papers return `pdf_url=None` (download phase skips them gracefully).
- `search_openalex(query_terms, max_results=200)` — hits `https://api.openalex.org/works?search=...&mailto=...`, paginates, and returns the parsed list.
- `--source openalex` wired into `cmd_search` and `main()` arg validation. Usage string and error message updated.

### `configs/chemistry.yaml`
Domain: physical chemistry, HOF/MOF biocatalysis, enzyme immobilisation, electronic-vibronic effects.

- **concept_types**: framework, enzyme, cofactor, characterization-method, interaction, mechanism, redox-center, spectral-feature, material, technique, person, definition
- **relationship_types**: encapsulates, coordinates-to, characterized-by, modulates, couples-to, catalyzes, inhibits, stabilizes, subtype_of, synthesized-by, related_to, developed_by
- Full normalise table covering MOF/HOF/COF abbreviations, oxidoreductase enzymes (HRP, laccase, cytochrome P450), cofactors (FAD, haem, copper centres), characterisation methods (XRD, EPR, FTIR, BET, CV), and key interactions (vibronic coupling, PCET, pi-pi stacking)
- All prompt fields matching `audiology.yaml` structure: extraction_prompt, summary_system_prompt, summary_sections, survey_section_system, survey_abstract_domain, theme_domain_description, etc.

### `tests/test_lit_review.py`
25 tests, all passing — no network calls:
- `TestOpenAlexAbstract` (6 tests) — inverted-index reconstruction including multi-occurrence words, None/empty inputs, non-contiguous positions
- `TestParseOpenAlexWork` (13 tests) — dict-shape contract, DOI-as-base-id, OpenAlex-ID fallback, skip-on-no-abstract, author extraction, OA PDF URL
- `TestSearchOpenAlex` (6 tests) — mocked HTTP, empty results, network error, mailto in request URL

## Smoke test (real network call)
Query: `"hydrogen-bonded organic framework enzyme"` returned 3 papers including:
- *Enzyme Encapsulation in a Porous Hydrogen-Bonded Organic Framework* (Liang & Carraro, JACS 2019)
- *Hydrogen-bonded organic framework biomimetic entrapment allowing non-native bioc...* (Chen & Tong, Nature Comm. 2022)
- *Co-encapsulating Cofactor and Enzymes in Hydrogen-Bonded Organic Frameworks...* (Liu & Sun, Angew. Chem. 2023)

## Test results
```
181 passed, 0 failed (full suite, excluding playwright E2E)
```

## Notes
- Paywalled papers (no OA PDF) are handled gracefully: `pdf_url=None`, download phase skips them with an existing "no free PDF" message. Users get metadata and abstracts for ranking/KG extraction even without PDFs.
- The chemistry config's `search_query_domain` is set to `"MOF HOF enzyme immobilisation biocatalysis electronic vibronic"` to seed structural-hole searches appropriately.
- This PR does not touch any deployment files (`fly.toml`, `apd-research/`, `.github/workflows/fly-deploy.yml`).

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)